### PR TITLE
Fix errors that ocurred when exporting an empty course

### DIFF
--- a/moodler/assignment.py
+++ b/moodler/assignment.py
@@ -150,6 +150,10 @@ def get_assignments_by_field(course_id, field=None, assignments_fields=None):
     all_assignment_jsons = mod_assign_get_assignments(course_id)
     assignment_ids = [assign['id'] for assign in all_assignment_jsons]
 
+    if 0 == len(assignment_ids):
+        logger.warning("No assignments were detected for course %s", course_id)
+        return assignment_ids
+
     grades = mod_assign_get_grades(assignment_ids)
     submissions = mod_assign_get_submissions(assignment_ids)
     assignments = []

--- a/moodler/assignment.py
+++ b/moodler/assignment.py
@@ -150,7 +150,7 @@ def get_assignments_by_field(course_id, field=None, assignments_fields=None):
     all_assignment_jsons = mod_assign_get_assignments(course_id)
     assignment_ids = [assign['id'] for assign in all_assignment_jsons]
 
-    if 0 == len(assignment_ids):
+    if not assignment_ids:
         logger.warning("No assignments were detected for course %s", course_id)
         return assignment_ids
 

--- a/moodler/moodle.py
+++ b/moodler/moodle.py
@@ -162,8 +162,8 @@ def export_materials(course_id, folder):
                 for attachment in assign.attachments:
                     download_file(attachment, section_folder)
             else:
-                logger.warn("Skipped export from unknown module '%s'",
-                             module['modname'])
+                logger.warning("Skipped export from unknown module '%s'",
+                               module['modname'])
 
 
 def export_grades(course_id, output_path, should_export_feedback=False):

--- a/moodler/moodle_api.py
+++ b/moodler/moodle_api.py
@@ -19,11 +19,24 @@ def validate_response(function_name, response):
     Function that validates whether the response received is a valid response or
     is it an exception.
     """
-    if 'exception' in response:
-        raise MoodleAPIException("Moodle API call for function '{}' returned "
-                                 "an exception response with the following "
-                                 "message: {}".format(function_name,
-                                                      response['message']))
+    # In some of the moodle requests a list is returned instead
+    if isinstance(response, dict):
+        if "exception" in response:
+            raise MoodleAPIException(
+                "Moodle API call for function '{}' returned "
+                "an exception response with the following "
+                "message: {}".format(function_name, response["message"])
+            )
+
+        if response.get("warnings", []):
+            # Warning example:
+            # User is not enrolled or does not have requested capability
+
+            raise MoodleAPIException(
+                "Moodle API call for function '%s' returned the following warning: %s",
+                function_name,
+                "".join(response.warnings),
+            )
 
 
 def build_url(moodle_function, **kwargs):
@@ -39,11 +52,11 @@ def build_url(moodle_function, **kwargs):
         if isinstance(arg_value, list):
             # Appending the list of arguments into the URL for the request
             for i, arg_value_item in enumerate(arg_value):
-                url += '&{}[{}]={}'.format(arg_name, i, arg_value_item)
+                url += "&{}[{}]={}".format(arg_name, i, arg_value_item)
 
         else:
             # Appending the argument into the URL as a parameter.
-            url += '&{}={}'.format(arg_name, arg_value)
+            url += "&{}={}".format(arg_name, arg_value)
 
     return url
 


### PR DESCRIPTION
I split this into three commits to make it easy for review.
The changes are:
1. Handle a case where a course has no assignments
2. Handle a case where a course has no grades
3. Handle API calls that return warnings (treat warning as an exception)
4. Add downloading "folders" capability