### PR TITLE
Hotfix/course with no assignments

### DIFF
--- a/moodler/adminer_commands.py
+++ b/moodler/adminer_commands.py
@@ -4,6 +4,7 @@ interface in the Moodle UI.
 """
 import re
 
+from moodler.moodle_exception import MoodlerException
 from moodler.config import URL
 
 
@@ -69,7 +70,7 @@ DB_NAME = "bitnami_moodle"
 ADMINER_PAGE = "/local/adminer/lib/run_adminer.php"
 
 
-class AdminerException(Exception):
+class AdminerException(MoodlerException):
     pass
 
 

--- a/moodler/assignment.py
+++ b/moodler/assignment.py
@@ -2,6 +2,7 @@ import logging
 import requests
 
 from moodler.config import URL
+from moodler.moodle_exception import MoodlerException
 from moodler.moodle_api import call_moodle_api
 from moodler.students import get_user_name, get_students_ids_by_name
 from moodler.submission import Submission, mod_assign_get_submissions, MissingGrade
@@ -9,7 +10,7 @@ from moodler.submission import Submission, mod_assign_get_submissions, MissingGr
 logger = logging.getLogger(__name__)
 
 
-class AssignmentException(Exception):
+class AssignmentException(MoodlerException):
     pass
 
 

--- a/moodler/assignment.py
+++ b/moodler/assignment.py
@@ -9,7 +9,15 @@ from moodler.submission import Submission, mod_assign_get_submissions, MissingGr
 logger = logging.getLogger(__name__)
 
 
-class InvalidAssignmentID(Exception):
+class AssignmentException(Exception):
+    pass
+
+
+class InvalidAssignmentID(AssignmentException):
+    pass
+
+
+class EmptyCourseError(AssignmentException):
     pass
 
 
@@ -139,6 +147,11 @@ def mod_assign_get_assignments(course_id):
     course
     """
     response = call_moodle_api("mod_assign_get_assignments", courseids=[course_id])
+
+    if not response["courses"]:
+        raise EmptyCourseError(
+            "Received an empty course. It could be that the course does not have any assignments."
+        )
 
     return response["courses"][0]["assignments"]
 

--- a/moodler/download.py
+++ b/moodler/download.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 import urllib.request
 
+from moodler.moodle_exception import MoodlerException
 from moodler.config import TOKEN, URL
 
 
@@ -25,7 +26,7 @@ REPORT_DIGITS_AFTER_DECIMAL_POINT = 2
 REPORT_FILE_NAME_FORMAT = "{} Report" + COURSE_REPORT_EXT
 
 
-class DownloadException(Exception):
+class DownloadException(MoodlerException):
     pass
 
 

--- a/moodler/moodle_api.py
+++ b/moodler/moodle_api.py
@@ -4,14 +4,11 @@ This file should contain general logic for every Moodle API call.
 import requests
 import logging
 
+from moodler.moodle_exception import MoodlerException
 from moodler.consts import REQUEST_FORMAT
 
 
 logger = logging.getLogger(__name__)
-
-
-class MoodlerException(Exception):
-    pass
 
 
 class MoodleAPIException(MoodlerException):

--- a/moodler/moodle_connect.py
+++ b/moodler/moodle_connect.py
@@ -13,6 +13,7 @@ import re
 import logging
 import requests
 
+from moodler.moodle_exception import MoodlerException
 from moodler.config import URL, LOGIN_PAGE
 
 logger = logging.getLogger(__name__)
@@ -21,7 +22,7 @@ LOGIN_TOKEN_PATTERN = r'name="logintoken" value="([\w\d]+)"'
 FAILED_LOGIN_PATTERN = r"Invalid login"
 
 
-class MoodleLoginException(Exception):
+class MoodleLoginException(MoodlerException):
     pass
 
 

--- a/moodler/moodle_csv.py
+++ b/moodler/moodle_csv.py
@@ -3,6 +3,7 @@ import sys
 import os
 import csv
 
+from moodler.moodle_exception import MoodlerException
 from moodler.config import STUDENTS_TO_IGNORE
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ STUDENT_INDEX = 1
 STATUS_INDEX = 3
 
 
-class InvalidCsv(Exception):
+class InvalidCsv(MoodlerException):
     def __init__(self, csv_path):
         super().__init__("CSV that shouldn't be processed found at '%s'" % csv_path)
 

--- a/moodler/moodle_exception.py
+++ b/moodler/moodle_exception.py
@@ -1,0 +1,7 @@
+"""
+This will contain the general exceptions for the whole project. This way,
+any exception could be caught with the root MoodlerException.
+"""
+
+class MoodlerException(Exception):
+    pass

--- a/moodler/sections.py
+++ b/moodler/sections.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from parse import parse
 
+from moodler.moodle_exception import MoodlerException
 from moodler.assignment import get_assignments
 from moodler.moodle_api import call_moodle_api
 
@@ -9,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 # Exceptions for the current module ###
-class SectionsException(Exception):
+class SectionsException(MoodlerException):
     pass
 
 

--- a/moodler/sections.py
+++ b/moodler/sections.py
@@ -76,8 +76,8 @@ def list_courses(course_prefix=None):
     for course in courses_from_moodle:
         if (
             course_prefix is None
-            or course["shortname"].starts_with(course_prefix)
-            or course["fullname"].starts_with(course_prefix)
+            or course["shortname"].startswith(course_prefix)
+            or course["fullname"].startswith(course_prefix)
         ):
             courses_list.append(
                 Course(course["id"], course["shortname"], course["fullname"])

--- a/moodler/students.py
+++ b/moodler/students.py
@@ -1,13 +1,14 @@
 import requests
 import logging
 
+from moodler.moodle_exception import MoodlerException
 from moodler.consts import REQUEST_FORMAT
 from moodler.moodle_api import call_moodle_api, validate_response
 
 logger = logging.getLogger(__name__)
 
 
-class TwoStudentsFoundConflict(Exception):
+class TwoStudentsFoundConflict(MoodlerException):
     pass
 
 

--- a/moodler/submission.py
+++ b/moodler/submission.py
@@ -1,9 +1,10 @@
 import requests
 
+from moodler.moodle_exception import MoodlerException
 from moodler.moodle_api import call_moodle_api
 
 
-class MissingGrade(Exception):
+class MissingGrade(MoodlerException):
     pass
 
 


### PR DESCRIPTION
1. Added a handling in the `mod_assign_get_assignments` for a case in which the course does not have any assignments - empty coruse.
2. Added a root exception for easier handling of exceptions outside of the moodler.
3. Fixed a small bug in the `list_courses` function in which I accidentally used `str.starts_with`, which does not exists, while I should have used the `str.startswith`