### PR TITLE
Support default values for assignment fields

### DIFF
--- a/moodler/assignment.py
+++ b/moodler/assignment.py
@@ -102,7 +102,7 @@ class Assignment(object):
         if not students_ids:
             logger.warning("No student was found! Aborting...")
         else:
-            mod_assign_lock_submissions(self.uid, students_ids)
+            mod_assign_lock_submissions(self.uid, list(students_ids))
 
             logger.info(
                 "Locked submissions for assignment '%s' for %s",

--- a/moodler/assignment.py
+++ b/moodler/assignment.py
@@ -91,12 +91,13 @@ class Assignment(object):
         Locking submissions for this specific assignment.
         """
         if students_names is None:
-            if not only_lock_resubmissions:
-                students_ids = list(get_students(course_id).keys())
-            else:
-                students_ids = [sub.user_id for sub in self.submissions]
+            students_ids = list(get_students(course_id).keys())
         else:
             students_ids = get_students_ids_by_name(course_id, students_names)
+
+        if only_lock_resubmissions:
+            submitted_users = [sub.user_id for sub in self.submissions]
+            students_ids = set(submitted_users).intersection(students_ids)
 
         if not students_ids:
             logger.warning("No student was found! Aborting...")

--- a/moodler/assignment.py
+++ b/moodler/assignment.py
@@ -29,6 +29,11 @@ class EmptyCourseError(AssignmentException):
     pass
 
 
+def default_get_json(json_object, target_field, default_value=""):
+    """Tries to get a field from a json object, returning a default value if the field doesn't exist"""
+    return json_object[target_field] if target_field in json_object else default_value
+
+
 class Assignment(object):
     def __init__(self, assignment_json, submissions_json, grades_json):
         # a random number Moodle generates in API (not seen when you use Moodle visually)
@@ -36,10 +41,10 @@ class Assignment(object):
         # the actual ID that you see in the Moodle interface
         self.cmid = assignment_json["cmid"]
         self.name = assignment_json["name"]
-        self.description = assignment_json["intro"]
+        self.description = default_get_json(assignment_json, "intro")
         self.attachments = [
             attachment["fileurl"]
-            for attachment in assignment_json["introattachments"]
+            for attachment in default_get_json(assignment_json, "introattachments", [])
         ]
 
         self.submissions = []
@@ -91,7 +96,7 @@ class Assignment(object):
         Locking submissions for this specific assignment.
         """
         if students_names is None:
-            students_ids = list(get_students(course_id).keys())
+            students_ids = [sub.user_id for sub in self.submissions]
         else:
             students_ids = get_students_ids_by_name(course_id, students_names)
 
@@ -105,7 +110,7 @@ class Assignment(object):
                 self.name,
                 students_names
                 if students_names is not None
-                else "all students.",
+                else "all students that submitted the assignment.",
             )
 
     def unlock_submissions(self, course_id, students_names=None):

--- a/moodler/sections.py
+++ b/moodler/sections.py
@@ -71,7 +71,7 @@ def get_assignments_by_section(course_id, sections_names=None, assignments_names
 
     if sections_names is not None:
         # Filter out section names
-        sections = [section for section in sections if section["name"] not in sections_names]
+        sections = [section for section in sections if section["name"] in sections_names]
 
         found_sections = set(section["name"] for section in sections)
         missing_sections = set(sections_names).difference(found_sections)


### PR DESCRIPTION
Support default values for assignment fields if they're not passed in the assignment json.

In some cases the moodle API will not return all the relevant assignment json fields (specifically, intro and introattachements). This change is to support passing default values for these fields instead of the script crashing.
