### PR TITLE
Adds debug info field to API exceptions if existent

### DIFF
--- a/moodler/moodle_api.py
+++ b/moodler/moodle_api.py
@@ -32,6 +32,7 @@ def validate_response(function_name, response):
         return
 
     if RESPONSE_EXCEPTION_KEY in response:
+        logger.debug(response)
         debug_info_suffix = ""
         if RESPONSE_DEBUG_INFO_KEY in response:
             debug_info_suffix = f'. Debug info: "{response[RESPONSE_DEBUG_INFO_KEY]}"'

--- a/moodler/moodle_api.py
+++ b/moodler/moodle_api.py
@@ -1,6 +1,7 @@
 """
 This file should contain general logic for every Moodle API call.
 """
+
 import logging
 
 import requests
@@ -40,7 +41,7 @@ def validate_response(function_name, response):
         raise MoodleAPIException(
             f'Moodle API call for function "{function_name}" returned '
             f'an exception response with the following message: "{response[RESPONSE_MESSAGE_KEY]}"'
-            f'{debug_info_suffix}'
+            f"{debug_info_suffix}"
         )
 
     warnings = response.get(RESPONSE_WARNINGS_KEY, [])


### PR DESCRIPTION
Made it so `MoodleAPIException`s now print out the debug info field returned from the Moodle API, which can be very useful in some cases. Here's the new error message format:

```python
moodler.moodle_api.MoodleAPIException: Moodle API call for function "core_course_get_courses" returned an exception response with the following message: "Access control exception". Debug info: "You are not allowed to use the rest protocol (missing capability: webservice/rest:use)"
```

As shown, the debug info contains crucial info about this error that wasn't available previously.

I also made it so the entire response is logged at debug level, which might be useful.